### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Alexey-Lukin/silken_net/security/code-scanning/5](https://github.com/Alexey-Lukin/silken_net/security/code-scanning/5)

In general, the fix is to define an explicit `permissions:` block minimizing the `GITHUB_TOKEN` scope. Since this workflow only checks out code, installs packages, runs tests, and uploads artifacts, it only needs read access to repository contents. The cleanest way to apply least privilege without changing existing behavior is to set a top‑level `permissions:` block (so it applies to all jobs) with `contents: read`.

Concretely, in `.github/workflows/ci.yml`, add a root‑level `permissions:` section after the `name: CI` line (before `on:`). This will apply to all jobs that don’t define their own `permissions:`. No existing steps require write access to PRs, issues, or contents, so `contents: read` is sufficient. No additional imports or external libraries are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
