### PR TITLE
fix(dev): argon2id ламався від glib — порядок require став несучим

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 require_relative "boot"
 
+# ⚠️ ПОРЯДОК НЕСУЧИЙ, не алфавіт. `rails/all` тягне activestorage/engine.rb, а той
+# у тілі класу згадує `ImageAnalyzer::Vips` → autoload → ruby-vips → glib. Якщо glib
+# заходить ПЕРШОЮ, нативний argon2id ламається на arm64-darwin: `__stack_chk_fail`
+# у `initial_hash`, SIGABRT (134) на ~50 хешах. Зворотний порядок чистий, тож
+# argon2id вантажимо до rails/all. Мінімальний репро (без Rails):
+#   ruby -e 'require "ruby-vips"; require "argon2id"; 50.times { Argon2id::Password.create("p") }'  → 134
+#   ruby -e 'require "argon2id"; require "ruby-vips"; …'                                            → 0
+# Linux (CI/Docker) не відтворює — тримаємо рядок для локальної сюїти на macOS.
+require "argon2id"
+
 require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
## Симптом

Після #493 (`ruby-vips` для CVE-2026-66066) **локальна** повна сюїта на arm64-darwin вмирає **SIGABRT (exit 134)**: `__stack_chk_fail` у `initial_hash` з `argon2id.bundle`. Два прогони впали на різних seed'ах (~35 і ~103 приклади) ⇒ корупція пам'яті, не конкретний тест. CI/Linux не відтворює.

Це блокувало наш стандарт «full suite before push» — локально він став неможливий.

## Причина — порядок завантаження, не vips і не argon2id окремо

Мінімальний репро **без Rails**:

| послідовність | exit |
|---|---|
| `argon2id` сам, 50 хешів | 0 |
| `ruby-vips` → `argon2id` | **134** |
| `argon2id` → `ruby-vips` | 0 |

glib, завантажена першою, ламає нативний argon2id. Зворотний порядок чистий.

**Чому Rails попадав у небезпечну гілку**, хоч `argon2id` стоїть 8-м рядком Gemfile: `require "rails/all"` (рядок 4 `application.rb`) виконується **до** `Bundler.require` (рядок 8), а тягне `activestorage/engine.rb`, який у тілі класу згадує `ImageAnalyzer::Vips` → autoload → `ruby-vips` → glib.

Зміряно через `$LOADED_FEATURES`:
- до фіксу: `vips=1026` / `argon2id=1245` — vips перший ❌
- після: `argon2id=407` / `vips=1031` ✅

До #493 гема не існувало, тож `rescue LoadError` гасив цей шлях і glib у процес не потрапляла — борг був невидимий, а не відсутній.

## Фікс

Один рядок — `require "argon2id"` перед `require "rails/all"`, з коментарем, що **порядок несучий** (інакше наступний «алфавітний» причісувач його зніме). Апстрім-фіксу немає: argon2id 0.10.0 (2026-04-07) — остання версія.

## Верифікація

- `bin/rspec` локально: **8361 examples, 0 failures**, line 99.53% / branch 98.07% — байт-у-байт як Linux-CI
- той самий прогін до фіксу: exit 134
- `bin/rubocop` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)